### PR TITLE
Minor bugfixes

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -50,7 +50,7 @@ plugins:
       file: .reek.yml
   rubocop:
     enabled: true
-    channel: rubocop-0-74
+    channel: rubocop-0-79
     config:
       file: .rubocop.yml
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,11 +26,14 @@ AllCops:
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
+Layout/LineLength:
+  Max: 120
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - "spec/**/*"
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: true
 
 Lint/UselessAssignment:
@@ -41,9 +44,6 @@ Metrics/AbcSize:
 
 Metrics/CyclomaticComplexity:
   Max: 7
-
-Metrics/LineLength:
-  Max: 120
 
 Metrics/MethodLength:
   Max: 13
@@ -68,12 +68,12 @@ Naming/ConstantName:
 Naming/FileName:
   Enabled: true
 
-Naming/RescuedExceptionsVariableName:
-  PreferredName: ex
-
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   AllowedNames:
     - ex
+
+Naming/RescuedExceptionsVariableName:
+  PreferredName: ex
 
 RSpec/AlignLeftLetBrace:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -19,9 +19,9 @@ platforms :mri do
   gem "redcarpet", "~> 3.4"
   gem "reek", ">= 5.3"
   gem "rspec-its"
-  gem "rubocop"
-  gem "rubocop-performance"
-  gem "rubocop-rspec"
+  gem "rubocop", "~> 0.79"
+  gem "rubocop-performance", "~> 1.5"
+  gem "rubocop-rspec", "~> 1.37"
   gem "simplecov-json"
   gem "travis"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,8 @@ platforms :mri do
   gem "reek", ">= 5.3"
   gem "rspec-its"
   gem "rubocop", "~> 0.79"
-  gem "rubocop-performance", "~> 1.5"
-  gem "rubocop-rspec", "~> 1.37"
+  gem "rubocop-performance"
+  gem "rubocop-rspec"
   gem "simplecov-json"
   gem "travis"
 end

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Let's take sidekiq-unique-jobs for example. It uses `brpoplpush-redis_script` li
 
 ```ruby
 # lib/my_redis_scripts.rb
-require "brpoplpush-redis_script"
+require "brpoplpush/redis_script"
 
 module SidekiqUniqueJobs::Scripts
   include Brpoplpush::RedisScript::DSL

--- a/lib/brpoplpush/redis_script/config.rb
+++ b/lib/brpoplpush/redis_script/config.rb
@@ -37,7 +37,7 @@ module Brpoplpush
       # @return [Pathname]
       #
       def scripts_path=(obj)
-        raise ArgumentError "#{obj} does not exist" unless Dir.exist?(obj.to_s)
+        raise(ArgumentError, "#{obj} does not exist") unless Dir.exist?(obj.to_s)
 
         @scripts_path =
           case obj

--- a/lib/brpoplpush/redis_script/template.rb
+++ b/lib/brpoplpush/redis_script/template.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "erb"
+
 module Brpoplpush
   # Interface to dealing with .lua files
   #
@@ -25,7 +27,7 @@ module Brpoplpush
       #
       def render(pathname)
         @partial_templates ||= {}
-        ERB.new(File.read(pathname)).result(binding)
+        ::ERB.new(File.read(pathname)).result(binding)
       end
 
       # helper method to include a lua partial within another lua script

--- a/spec/brpoplpush/redis_script/config_spec.rb
+++ b/spec/brpoplpush/redis_script/config_spec.rb
@@ -14,8 +14,18 @@ RSpec.describe Brpoplpush::RedisScript::Config do
   describe "scripts_path=" do
     subject(:set_scripts_path) { config.scripts_path = new_path }
 
-    let(:new_path) { SCRIPTS_PATH }
+    context "when directory exists" do
+      let(:new_path) { SCRIPTS_PATH }
 
-    it { expect { set_scripts_path }.to change { config.scripts_path }.from(nil).to(new_path) }
+      it { expect { set_scripts_path }.to change { config.scripts_path }.from(nil).to(new_path) }
+    end
+
+    context "when directory does not exist" do
+      let(:new_path) { SCRIPTS_PATH.join("non-existing", "path") }
+
+      it do
+        expect { set_scripts_path }.to raise_error(ArgumentError)
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ LOGLEVEL     = ENV.fetch("LOGLEVEL") { "ERROR" }.upcase
 SUPPORT_DIR  = Pathname.new(File.join(File.dirname(__FILE__), "support"))
 SCRIPTS_PATH = SUPPORT_DIR.join("lua")
 
-Dir[SUPPORT_DIR.join("**", "*.rb")].each { |f| require f }
+Dir[SUPPORT_DIR.join("**", "*.rb")].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.define_derived_metadata do |meta|


### PR DESCRIPTION
After a first usage in a minimal project I could find out

* [x] Prevent issues with cops getting renamed across the different rubocop versions
```
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
Error: The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Naming/UncommunicativeMethodParamName` cop has been renamed to `Naming/MethodParameterName`.
(obsolete configuration found in .rubocop.yml, please update it)
```
* [x] Missing require for `erb` and namespace escape
```
brpoplpush-redis_script-0.1.0/lib/brpoplpush/redis_script/template.rb:28:in `render'
NameError (uninitialized constant Brpoplpush::RedisScript::Template::ERB)
```
* [x] Wrong require in the README doc
* [x] No method error when directory does not exist
```
brpoplpush-redis_script-0.1.0/lib/brpoplpush/redis_script/config.rb:40:in `scripts_path=': undefined method `ArgumentError' for #<Brpoplpush::RedisScript::Config:0x00007f95492a83a8> (NoMethodError)
```

Reproduced and fixed in test:

```
  1) Brpoplpush::RedisScript::Config scripts_path= when directory does not exist is expected to raise ArgumentError
     Failure/Error: expect { set_scripts_path }.to raise_error(ArgumentError)

       expected ArgumentError, got #<NoMethodError: undefined method `ArgumentError' for #<Brpoplpush::RedisScript::Config:0x00007fa41fc61338>> with backtrace:
         # ./lib/brpoplpush/redis_script/config.rb:40:in `scripts_path='
         # ./spec/brpoplpush/redis_script/config_spec.rb:15:in `block (3 levels) in <top (required)>'
         # ./spec/brpoplpush/redis_script/config_spec.rb:28:in `block (5 levels) in <top (required)>'
         # ./spec/brpoplpush/redis_script/config_spec.rb:28:in `block (4 levels) in <top (required)>'
```