### PR TITLE
lint: pin rubocop related gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,9 @@ RSpec/AlignLeftLetBrace:
 RSpec/DescribeClass:
   Enabled: true
 
+RSpec/RepeatedDescription:
+  Enabled: false
+
 RSpec/ExampleLength:
   Enabled: true
 

--- a/.simplecov
+++ b/.simplecov
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "simplecov-json"
+require "simplecov-oj"
 
 SimpleCov.command_name "RSpec"
 # SimpleCov.refuse_coverage_drop
 SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
-  SimpleCov::Formatter::JSONFormatter,
+  SimpleCov::Formatter::OjFormatter,
 ]
 
 SimpleCov.start do

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,8 @@ platforms :mri do
   gem "reek", ">= 5.3"
   gem "rspec-its"
   gem "rubocop", "~> 0.79"
-  gem "rubocop-performance"
-  gem "rubocop-rspec"
+  gem "rubocop-performance", "~> 1.5.2"
+  gem "rubocop-rspec", "~> 1.37.0"
   gem "simplecov-json"
   gem "travis"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ platforms :mri do
   gem "rubocop", "~> 0.79"
   gem "rubocop-performance", "~> 1.5.2"
   gem "rubocop-rspec", "~> 1.37.0"
-  gem "simplecov-json"
+  gem "simplecov-oj", require: false
   gem "travis"
 end
 


### PR DESCRIPTION
After the last merge on master, the build is broken:
<https://travis-ci.com/brpoplpush/brpoplpush-redis_script/jobs/285799816>

This is due to the `rubocop-rspec` resolution to an higher version:
```
Fetching concurrent-ruby 1.1.6
Fetching rubocop-rspec 1.38.0
Installing rubocop-rspec 1.38.0
Installing concurrent-ruby 1.1.6
```

Version `1.38.0` was released two hours ago and introduced a few more cops:
```
spec/brpoplpush/redis_script/scripts_spec.rb:24:7: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
      its(:name) { is_expected.to eq(script_name) }
      ^^^^^^^^^^
spec/brpoplpush/redis_script/scripts_spec.rb:25:7: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
      its(:path) { is_expected.to eq(script_path) }
      ^^^^^^^^^^
spec/brpoplpush/redis_script/scripts_spec.rb:26:7: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
      its(:sha)  { is_expected.to eq(script_sha) }
      ^^^^^^^^^
spec/brpoplpush/redis_script/scripts_spec.rb:34:7: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
      its(:name) { is_expected.to eq(script_name) }
      ^^^^^^^^^^
spec/brpoplpush/redis_script/scripts_spec.rb:35:7: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
      its(:path) { is_expected.to eq(script_path) }
      ^^^^^^^^^^
spec/brpoplpush/redis_script/scripts_spec.rb:36:7: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
      its(:sha)  { is_expected.to eq(script_sha) }
      ^^^^^^^^^
spec/brpoplpush/redis_script/scripts_spec.rb:53:5: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
    its(:class) { is_expected.to eq(Brpoplpush::RedisScript::Script) }
    ^^^^^^^^^^^
spec/brpoplpush/redis_script/scripts_spec.rb:54:5: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
    its(:name)  { is_expected.to eq(script_name) }
    ^^^^^^^^^^
spec/brpoplpush/redis_script/scripts_spec.rb:55:5: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
    its(:path)  { is_expected.to eq(script_path) }
    ^^^^^^^^^^
spec/brpoplpush/redis_script/scripts_spec.rb:56:5: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
    its(:sha)   { is_expected.to eq(script_sha) }
    ^^^^^^^^^
```