### PR TITLE
Remove unused @conn in Config constructor

### DIFF
--- a/lib/brpoplpush/redis_script/config.rb
+++ b/lib/brpoplpush/redis_script/config.rb
@@ -21,7 +21,6 @@ module Brpoplpush
       #
       #
       def initialize
-        @conn         = Redis.new
         @logger       = Logger.new($stdout)
         @scripts_path = nil
       end


### PR DESCRIPTION
## Description

The issue is, `Redis.new` relies on a valid ENV['REDIS_URL'] which will be used as the default url. This seems like an unnecessary dependency.

## Why this PR?

I can't really see the use-case for defining `@conn` here, it's not used anywhere, and so I guess the only usage is for inheriting from this config class (?).

My issue is, with my setup, I get an error in this `Redis.new` initialization because I don't have a full redis url in `ENV['REDIS_URL']`.