### PR TITLE
Fix evalsha interface for Sidekiq 7

### DIFF
--- a/brpoplpush-redis_script.gemspec
+++ b/brpoplpush-redis_script.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.5"
-  spec.add_dependency "redis", ">= 1.0", "<= 5.0"
+  spec.add_dependency "redis", ">= 1.0", "< 6"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.3"

--- a/lib/brpoplpush/redis_script/scripts.rb
+++ b/lib/brpoplpush/redis_script/scripts.rb
@@ -112,7 +112,7 @@ module Brpoplpush
       #
       def execute(name, conn, keys: [], argv: [])
         script = fetch(name, conn)
-        conn.evalsha(script.sha, keys: keys, argv: argv)
+        conn.evalsha(script.sha, keys, argv)
       end
 
       def count


### PR DESCRIPTION
Sidekiq 7 changed the connection it returns - it used to be a `Redis` instance, and now it is a `RedisClient` instance wrapped in `Sidekiq::RedisClientAdapter::CompatClient`.

The `Redis` `evalsha` interface took `keys` and `argv` as key arguments or positional arguments. `CompatClient` only takes them as positional arguments, so it raises an error if you try to `evalsha` with keys, which breaks inside of `sidekiq-unique-jobs` since it uses the Sidekiq redis connection pool if it is available.

This is one of two issues that `sidekiq-unique-jobs` has with `evalsha`. The other is that `redis` gem version 5+ changed some behavior around casting values to strings automatically. As a result if you run:

```rb
# argv => [true, false]
conn.evalsha(script.sha, keys, argv)
```

This will raise an error: `Unsupported command argument type: TrueClass` (you can simulate this in `spec/brpoplpush/redis_script/client_spec.rb` by changing the `let(:argv)` to be boolean values).

In `redis` gem versions < 5, this would have been cast to a string. Initially when I updated the `evalsha` code I changed it to:

```rb
conn.evalsha(script.sha, keys, argv.map(&:to_s)
```

But based on the discussion in this `Redis 5` compatibility issue for the `redis` repo, I decided that was a bad idea:

https://github.com/redis/redis-rb/issues/1142#issuecomment-1288507066
https://gitlab.com/gitlab-org/gitlab/-/issues/371098

Automatically calling `to_s` on all arguments can lead to remote code exploits. My feeling is that the `sidekiq-unique-jobs` gem should instead manage calling `to_s` on arguments as necessary when handing them into `Scripts.execute`. It's your gem so of course it's up to you!