### PR TITLE
Handle RedisClient CommandErrors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,19 @@ platforms :mri do
   gem "travis"
 end
 
+group :development do
+  gem "bundler", "~> 2.0"
+  gem "rake", "~> 12.3"
+  gem "rspec", "~> 3.7"
+
+  # ===== Documentation =====
+  gem "github_changelog_generator", "~> 1.14"
+  gem "github-markup", "~> 3.0"
+  # gem  "redcarpet", "~> 3.4"
+  gem "yard", "~> 0.9.18"
+
+  # ===== Release Management =====
+  gem "gem-release", "~> 2.0"
+end
+
 eval(File.read(LOCAL_GEMS)) if File.exist?(LOCAL_GEMS) # rubocop:disable Security/Eval

--- a/brpoplpush-redis_script.gemspec
+++ b/brpoplpush-redis_script.gemspec
@@ -33,17 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.5"
   spec.add_dependency "redis", ">= 1.0", "< 6"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "rspec", "~> 3.7"
-
-  # ===== Documentation =====
-  spec.add_development_dependency "github_changelog_generator", "~> 1.14"
-  spec.add_development_dependency "github-markup", "~> 3.0"
-  # spec.add_development_dependency "redcarpet", "~> 3.4"
-  spec.add_development_dependency "yard", "~> 0.9.18"
-
-  # ===== Release Management =====
-  spec.add_development_dependency "gem-release", "~> 2.0"
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/lib/brpoplpush/redis_script/client.rb
+++ b/lib/brpoplpush/redis_script/client.rb
@@ -47,7 +47,7 @@ module Brpoplpush
 
         logger.debug("Executed #{script_name}.lua in #{elapsed}ms")
         result
-      rescue ::Redis::CommandError => ex
+      rescue ::Redis::CommandError, ::RedisClient::CommandError => ex
         handle_error(script_name, conn, ex) do
           execute(script_name, conn, keys: keys, argv: argv)
         end
@@ -58,7 +58,7 @@ module Brpoplpush
       #
       # Handle errors to allow retrying errors that need retrying
       #
-      # @param [Redis::CommandError] ex exception to handle
+      # @param [Redis::CommandError, ::Redis::CommandError] ex exception to handle
       #
       # @return [void]
       #
@@ -84,7 +84,7 @@ module Brpoplpush
 
       def handle_busy(conn)
         scripts.kill(conn)
-      rescue ::Redis::CommandError => ex
+      rescue ::Redis::CommandError, ::RedisClient::CommandError => ex
         logger.warn(ex)
       ensure
         yield

--- a/lib/brpoplpush/redis_script/client.rb
+++ b/lib/brpoplpush/redis_script/client.rb
@@ -58,7 +58,7 @@ module Brpoplpush
       #
       # Handle errors to allow retrying errors that need retrying
       #
-      # @param [Redis::CommandError, ::Redis::CommandError] ex exception to handle
+      # @param [Redis::CommandError, ::RedisClient::CommandError] ex exception to handle
       #
       # @return [void]
       #

--- a/lib/brpoplpush/redis_script/dsl.rb
+++ b/lib/brpoplpush/redis_script/dsl.rb
@@ -40,7 +40,7 @@ module Brpoplpush
             yield config
           else
             options.each do |key, val|
-              config.send("#{key}=", val)
+              config.send(:"#{key}=", val)
             end
           end
         end

--- a/spec/brpoplpush/redis_script/client/execute_spec.rb
+++ b/spec/brpoplpush/redis_script/client/execute_spec.rb
@@ -131,4 +131,92 @@ RSpec.describe Brpoplpush::RedisScript::Client, "#execute" do
       end
     end
   end
+
+  context "when redis client error is raised" do
+    before do
+      allow(Brpoplpush::RedisScript::Scripts).to receive(:fetch).with(config.scripts_path).and_return(scripts)
+      allow(scripts).to receive(:delete).and_return(true)
+      allow(scripts).to receive(:kill).and_return(true)
+      allow(scripts).to receive(:load).and_return(true)
+      allow(scripts).to receive(:fetch).and_return(script)
+
+      allow(client.logger).to receive(:warn).and_return(true)
+      allow(client.logger).to receive(:debug).and_return(true)
+
+      call_count = 0
+      allow(scripts).to receive(:execute) do
+        call_count += 1
+        call_count.odd? ? raise(RedisClient::CommandError, redis_error_message) : "bogus"
+      end
+
+      exception
+    end
+
+    context "when message starts with ERR" do
+      let(:redis_error_message) do
+        <<~ERR
+          ERR Error running script (execute to f_178d75adaa46af3d8237cfd067c9fdff7b9d504f): [string "func definition"]:7: attempt to compare nil with number
+        ERR
+      end
+
+      let(:error_message) do
+        <<~ERR_MSG
+          attempt to compare nil with number
+
+              5: local key_fiv = KEYS[5]
+              6: local arg_one = ARGV[1]
+           => 7: local arg_two = ARGV[2]
+              8: local arg_tre = ARGV[3]
+              9: local arg_for = ARGV[4]
+
+        ERR_MSG
+      end
+
+      let(:exception) do
+        execute
+      rescue Brpoplpush::RedisScript::LuaError => ex
+        ex
+      end
+
+      specify do
+        expect(exception.message).to eq(error_message)
+        expect(exception.backtrace.first).to match(%r{spec/support/lua/test.lua:7})
+        expect(exception.backtrace[1]).to match(/client.rb/)
+
+        expect(scripts).not_to have_received(:delete)
+        expect(scripts).to have_received(:execute).with(script_name, redis, keys: keys, argv: argv).once
+      end
+    end
+
+    context "when message starts with BUSY" do
+      let(:redis_error_message) do
+        "BUSY Redis is busy running a script. " \
+          "You can only execute SCRIPT KILL or SHUTDOWN NOSAVE."
+      end
+
+      context "when .script(:kill) raises CommandError" do
+        before do
+          allow(scripts).to receive(:kill).and_raise(RedisClient::CommandError, "NOT BUSY")
+          allow(client.logger).to receive(:warn)
+        end
+
+        specify do
+          expect { execute }.not_to raise_error
+          expect(client.logger).to have_received(:warn).with(kind_of(RedisClient::CommandError))
+          expect(scripts).to have_received(:execute).with(script_name, redis, keys: keys, argv: argv).twice
+        end
+      end
+    end
+
+    context "when message starts with NOSCRIPT" do
+      let(:redis_error_message) { "NOSCRIPT No matching script. Please use EVAL." }
+
+      specify do
+        expect { execute }.not_to raise_error
+
+        expect(scripts).to have_received(:delete).with(script_name)
+        expect(scripts).to have_received(:execute).with(script_name, redis, keys: keys, argv: argv).twice
+      end
+    end
+  end
 end

--- a/spec/brpoplpush/redis_script/client/execute_spec.rb
+++ b/spec/brpoplpush/redis_script/client/execute_spec.rb
@@ -34,13 +34,9 @@ RSpec.describe Brpoplpush::RedisScript::Client, "#execute" do
   context "when error is raised" do
     before do
       allow(Brpoplpush::RedisScript::Scripts).to receive(:fetch).with(config.scripts_path).and_return(scripts)
-      allow(scripts).to receive(:delete).and_return(true)
-      allow(scripts).to receive(:kill).and_return(true)
-      allow(scripts).to receive(:load).and_return(true)
-      allow(scripts).to receive(:fetch).and_return(script)
+      allow(scripts).to receive_messages(delete: true, kill: true, load: true, fetch: script)
 
-      allow(client.logger).to receive(:warn).and_return(true)
-      allow(client.logger).to receive(:debug).and_return(true)
+      allow(client.logger).to receive_messages(warn: true, debug: true)
 
       call_count = 0
       allow(scripts).to receive(:execute) do
@@ -135,13 +131,9 @@ RSpec.describe Brpoplpush::RedisScript::Client, "#execute" do
   context "when redis client error is raised" do
     before do
       allow(Brpoplpush::RedisScript::Scripts).to receive(:fetch).with(config.scripts_path).and_return(scripts)
-      allow(scripts).to receive(:delete).and_return(true)
-      allow(scripts).to receive(:kill).and_return(true)
-      allow(scripts).to receive(:load).and_return(true)
-      allow(scripts).to receive(:fetch).and_return(script)
+      allow(scripts).to receive_messages(delete: true, kill: true, load: true, fetch: script)
 
-      allow(client.logger).to receive(:warn).and_return(true)
-      allow(client.logger).to receive(:debug).and_return(true)
+      allow(client.logger).to receive_messages(warn: true, debug: true)
 
       call_count = 0
       allow(scripts).to receive(:execute) do

--- a/spec/brpoplpush/redis_script/logging_spec.rb
+++ b/spec/brpoplpush/redis_script/logging_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Brpoplpush::RedisScript::Logging do
     end
 
     it "delegates to logger" do
-      expect(logging.send("log_#{level}".to_sym, message)).to be_nil
+      expect(logging.send(:"log_#{level}", message)).to be_nil
       expect(logger).to have_received(level).with(message)
     end
   end

--- a/spec/brpoplpush/redis_script/lua_error_spec.rb
+++ b/spec/brpoplpush/redis_script/lua_error_spec.rb
@@ -25,5 +25,25 @@ RSpec.describe Brpoplpush::RedisScript::LuaError do
 
       it { is_expected.to be(true) }
     end
+
+    context "when error contains redis client ERR Error running script" do
+      let(:error)   { RedisClient::CommandError.new(message) }
+      let(:message) do
+        'ERR Error running script (execute to f_178d75adaa46af3d8237cfd067c9fdff7b9d504f): ' \
+          '[string "func definition"]:7: attempt to compare nil with number'
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when error contains redis client ERR Error compiling script" do
+      let(:error)   { RedisClient::CommandError.new(message) }
+      let(:message) do
+        'ERR Error compiling script (execute to f_178d75adaa46af3d8237cfd067c9fdff7b9d504f): ' \
+          '[string "func definition"]:7: attempt to compare nil with number'
+      end
+
+      it { is_expected.to be(true) }
+    end
   end
 end


### PR DESCRIPTION
We had an outage of our Redis instance at the weekend and we're using Sidekiq 7 which has the `RedisClient` module for errors so the `NOSCRIPT` errors were not handled correctly.

Since we want to ensure we don't need to manually intervene to roll our deployments when this happens, I figured a quick upstream fix would help here.

